### PR TITLE
Add `before_transaction_commit`

### DIFF
--- a/lib/ar_after_transaction.rb
+++ b/lib/ar_after_transaction.rb
@@ -14,9 +14,15 @@ module ARAfterTransaction
 
     def transaction_with_after(*args)
       clean = true
+      outermost_transaction = true unless transactions_open?
       transaction_without_after(*args) do
         begin
-          yield
+          yield.tap do
+            if outermost_transaction
+              callbacks = delete_before_transaction_commit_callbacks
+              callbacks.each(&:call)
+            end
+          end
         rescue ActiveRecord::Rollback
           clean = false
           raise
@@ -27,8 +33,18 @@ module ARAfterTransaction
       raise
     ensure
       unless transactions_open?
+        delete_before_transaction_commit_callbacks
         callbacks = delete_after_transaction_callbacks
         callbacks.each(&:call) if clean
+      end
+    end
+
+    def before_transaction_commit(&block)
+      if transactions_open?
+        connection.before_transaction_commit_callbacks ||= []
+        connection.before_transaction_commit_callbacks << block
+      else
+        yield
       end
     end
 
@@ -62,11 +78,21 @@ module ARAfterTransaction
       connection.after_transaction_callbacks = []
       result
     end
+
+    def delete_before_transaction_commit_callbacks
+      result = connection.before_transaction_commit_callbacks || []
+      connection.before_transaction_commit_callbacks = []
+      result
+    end
   end
 
   module InstanceMethods
     def after_transaction(&block)
       self.class.after_transaction(&block)
+    end
+
+    def before_transaction_commit(&block)
+      self.class.before_transaction_commit(&block)
     end
   end
 end
@@ -76,6 +102,7 @@ module ARAfterTransactionConnection
     base.class_eval do
       attr_accessor :normally_open_transactions
       attr_accessor :after_transaction_callbacks
+      attr_accessor :before_transaction_commit_callbacks
     end
   end
 end

--- a/lib/ar_after_transaction/version.rb
+++ b/lib/ar_after_transaction/version.rb
@@ -1,3 +1,3 @@
 module ARAfterTransaction
-  VERSION = Version = '0.4.1'
+  VERSION = Version = '0.5.0'
 end


### PR DESCRIPTION
Any `before_transaction_commit` callbacks will be run right before a
transaction commits. They act as statements within the transaction,
can cause rollbacks, etc. But you can add these callbacks anywhere
within your transaction, and the code will be deferred until the end.